### PR TITLE
+Fixed typo in duplicate object found warning

### DIFF
--- a/GameAnalytics/Plugins/Scripts/GameAnalytics.cs
+++ b/GameAnalytics/Plugins/Scripts/GameAnalytics.cs
@@ -61,7 +61,7 @@ namespace GameAnalyticsSDK
 			if(_instance != null)
 			{
 				// only one system tracker allowed per scene
-				Debug.LogWarning("Destroying dublicate GameAnalytics object - only one is allowed per scene!");
+				Debug.LogWarning("Destroying duplicate GameAnalytics object - only one is allowed per scene!");
 				Destroy(gameObject);
 				return;
 			}


### PR DESCRIPTION
Old  message contained `duplicate`, renamed to `duplicate`